### PR TITLE
Add Firebase rainfall monitor page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # arg-firebasewebsite
-kkn desa kamulyan
+
+Simple webpage that displays the current rainfall value from Firebase Realtime Database.
+
+## Development
+
+1. Edit `index.html` and replace the Firebase configuration object with your project credentials.
+2. Open the page in a browser; it will display updates from `rainfall/current` when values change.
+
+## Hosting
+
+For easy deployment you can host the page using [Firebase Hosting](https://firebase.google.com/docs/hosting):
+
+1. Install the Firebase CLI: `npm install -g firebase-tools`.
+2. Log in and initialize hosting in this folder: `firebase login` then `firebase init hosting`.
+3. Deploy the site with `firebase deploy`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Rainfall Monitor</title>
+</head>
+<body>
+  <h1>Rainfall Monitor</h1>
+  <p>Current rainfall: <span id="rainfall">--</span></p>
+
+  <script type="module">
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js";
+    import { getDatabase, ref, onValue } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-database.js";
+
+    // TODO: Replace with your Firebase project configuration
+    const firebaseConfig = {
+      apiKey: "YOUR_API_KEY",
+      authDomain: "YOUR_PROJECT_ID.firebaseapp.com",
+      databaseURL: "https://YOUR_PROJECT_ID.firebaseio.com",
+      projectId: "YOUR_PROJECT_ID",
+      storageBucket: "YOUR_PROJECT_ID.appspot.com",
+      messagingSenderId: "YOUR_SENDER_ID",
+      appId: "YOUR_APP_ID"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const db = getDatabase(app);
+    const rainfallRef = ref(db, 'rainfall/current');
+
+    const rainfallEl = document.getElementById('rainfall');
+    onValue(rainfallRef, (snapshot) => {
+      const value = snapshot.val();
+      rainfallEl.textContent = value !== null ? value : '--';
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `index.html` demonstrating Firebase SDK usage and rainfall subscription
- Document development and optional Firebase Hosting deployment steps

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689551b3c52c8331ae15094005ed9755