### PR TITLE
Add rainfall logging and alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # arg-firebasewebsite
+
 kkn desa kamulyan
+
+## Rainfall logging
+
+Cloud Functions are provided to log rainfall measurements and aggregate daily totals.
+
+- `logRainfall` HTTP endpoint pushes `{timestamp, amount}` entries to `rainfall/logs`.
+- `aggregateDailyRainfall` scheduled job sums the day's logs into `rainfall/dailyTotals/`.
+- When daily rain exceeds `RAINFALL_LIMIT` an FCM notification is sent to the `rainfallAlerts` topic.

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,56 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+admin.initializeApp();
+
+// HTTP endpoint to log rainfall readings
+exports.logRainfall = functions.https.onRequest(async (req, res) => {
+  try {
+    const amount = Number(req.body.amount);
+    if (isNaN(amount)) {
+      res.status(400).json({ error: 'amount required' });
+      return;
+    }
+    const entry = { timestamp: Date.now(), amount };
+    await admin.database().ref('rainfall/logs').push(entry);
+    res.json({ status: 'logged', entry });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Scheduled function to aggregate daily rainfall totals
+exports.aggregateDailyRainfall = functions.pubsub.schedule('0 0 * * *').onRun(async () => {
+  const now = new Date();
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 1);
+
+  const logsRef = admin.database().ref('rainfall/logs');
+  const snapshot = await logsRef
+    .orderByChild('timestamp')
+    .startAt(start.getTime())
+    .endAt(end.getTime() - 1)
+    .once('value');
+
+  let total = 0;
+  snapshot.forEach(child => {
+    const val = child.val();
+    total += Number(val.amount) || 0;
+  });
+
+  const dateKey = start.toISOString().split('T')[0];
+  await admin.database().ref(`rainfall/dailyTotals/${dateKey}`).set(total);
+
+  const limit = Number(process.env.RAINFALL_LIMIT || 100);
+  if (total > limit) {
+    await admin.messaging().send({
+      topic: 'rainfallAlerts',
+      notification: {
+        title: 'Heavy Rainfall',
+        body: `Rainfall reached ${total}mm on ${dateKey}`,
+      },
+    });
+  }
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "functions",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.3.0"
+  }
+}


### PR DESCRIPTION
## Summary
- log rainfall readings to `rainfall/logs` via HTTP Cloud Function
- schedule daily aggregation and send FCM alerts when totals exceed limit
- document rainfall functions in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689551b5d68483319505620b2d6f2e71